### PR TITLE
feat(apple-music): sync songs and lyrics with Apple Music catalog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,19 @@ SMTP_PASSWORD=RobotSkeli2025!
 SMTP_FROM=robot@skeli.cz
 SMTP_FROM_NAME=Skeli Robot
 SMTP_ENCRYPTION=tls
+
+# Apple Music API (MusicKit) — see https://developer.apple.com/documentation/applemusicapi
+# Obtain from Apple Developer: Certificates, Identifiers & Profiles -> Keys -> MusicKit
+APPLE_MUSIC_TEAM_ID=XXXXXXXXXX
+APPLE_MUSIC_KEY_ID=YYYYYYYYYY
+# Paste contents of the .p8 file (newlines replaced with \n or as-is in a multi-line env)
+APPLE_MUSIC_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nMIGHAgEA...\n-----END PRIVATE KEY-----
+# Music User Token — required for lyrics; generate via MusicKit JS in a browser with Apple Music subscription
+APPLE_MUSIC_USER_TOKEN=
+# Apple Music storefront (country code, e.g. cz, us, gb)
+APPLE_MUSIC_STOREFRONT=cz
+# Artist name used in catalog search queries
+APPLE_MUSIC_ARTIST=Skeli
+# Apple Music Artist ID — find it on music.apple.com in the artist URL (e.g. /artist/skeli/1234567890)
+# When set, sync uses the full artist catalog instead of per-song text search (more accurate)
+APPLE_MUSIC_ARTIST_ID=

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,12 @@
             <artifactId>java-dotenv</artifactId>
             <version>5.2.2</version>
         </dependency>
+        <!-- JWT signing for Apple Music developer token (ES256) -->
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>9.37.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/skeliit/AppleMusicSyncServlet.java
+++ b/src/main/java/com/github/skeliit/AppleMusicSyncServlet.java
@@ -1,0 +1,125 @@
+package com.github.skeliit;
+
+import com.github.skeliit.dao.LyricDao;
+import com.github.skeliit.dao.SongDao;
+import com.github.skeliit.model.Song;
+import com.github.skeliit.service.AppleMusicClient;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@WebServlet(name = "AppleMusicSyncServlet", urlPatterns = {"/admin/apple-sync"})
+public class AppleMusicSyncServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        Object role = req.getSession().getAttribute("role");
+        if (role == null || !"ADMIN".equals(role.toString())) {
+            resp.setStatus(403);
+            resp.getWriter().write("Forbidden");
+            return;
+        }
+
+        String teamId     = System.getenv("APPLE_MUSIC_TEAM_ID");
+        String keyId      = System.getenv("APPLE_MUSIC_KEY_ID");
+        String privateKey = System.getenv("APPLE_MUSIC_PRIVATE_KEY");
+        String userToken  = System.getenv("APPLE_MUSIC_USER_TOKEN");
+        String storefront = System.getenv("APPLE_MUSIC_STOREFRONT");
+        String artist     = System.getenv("APPLE_MUSIC_ARTIST");
+        String artistId   = System.getenv("APPLE_MUSIC_ARTIST_ID");
+
+        if (teamId == null || keyId == null || privateKey == null) {
+            resp.setStatus(500);
+            resp.getWriter().write("Missing Apple Music configuration: APPLE_MUSIC_TEAM_ID, APPLE_MUSIC_KEY_ID, APPLE_MUSIC_PRIVATE_KEY");
+            return;
+        }
+        if (storefront == null) storefront = "us";
+        if (artist == null) artist = "Skeli";
+
+        AppleMusicClient client = new AppleMusicClient(teamId, keyId, privateKey, userToken, storefront, artist);
+        SongDao songDao = new SongDao();
+        LyricDao lyricDao = new LyricDao();
+
+        int synced = 0, lyricsStored = 0;
+        List<String> errors = new ArrayList<>();
+
+        try {
+            // When the artist's Apple Music ID is known, enumerate their full catalog first.
+            // This is more accurate than per-song text search.
+            Map<String, AppleMusicClient.SongMatch> catalogByName = new HashMap<>();
+            if (artistId != null && !artistId.isBlank()) {
+                for (AppleMusicClient.SongMatch m : client.listArtistSongs(artistId)) {
+                    catalogByName.put(AppleMusicClient.normalize(m.name()), m);
+                }
+            }
+
+            List<Song> songs = songDao.listAll();
+            for (Song song : songs) {
+                try {
+                    if (song.appleMusicId == null) {
+                        AppleMusicClient.SongMatch match = null;
+                        // Prefer artist catalog lookup over generic search
+                        if (!catalogByName.isEmpty()) {
+                            String key = AppleMusicClient.normalize(song.name);
+                            match = catalogByName.get(key);
+                            // Also try with year suffix stripped if no direct hit
+                            if (match == null) {
+                                for (Map.Entry<String, AppleMusicClient.SongMatch> e : catalogByName.entrySet()) {
+                                    if (e.getKey().contains(key) || key.contains(e.getKey())) {
+                                        // Prefer year match when both are known
+                                        String rd = e.getValue().releaseDate();
+                                        if (song.year == null || rd.isBlank() || rd.startsWith(String.valueOf(song.year))) {
+                                            match = e.getValue();
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        // Fall back to catalog search when artist ID not set or no match found
+                        if (match == null) {
+                            match = client.searchSong(song.name, song.year);
+                        }
+                        if (match != null) {
+                            songDao.updateAppleMusicId(song.id, match.id());
+                            song.appleMusicId = match.id();
+                            synced++;
+                        }
+                    } else {
+                        synced++;
+                    }
+
+                    if (song.appleMusicId != null && userToken != null && !userToken.isBlank()) {
+                        AppleMusicClient.AppleMusicLyrics lyrics = client.fetchLyrics(song.appleMusicId);
+                        if (lyrics != null) {
+                            lyricDao.upsertAppleMusicLyrics(song.id, lyrics.plainText(), lyrics.ttml(), "en");
+                            lyricsStored++;
+                        }
+                    }
+                } catch (Exception e) {
+                    errors.add(song.name + ": " + e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+
+        resp.setContentType("application/json; charset=UTF-8");
+        PrintWriter out = resp.getWriter();
+        out.print("{\"synced\":" + synced + ",\"lyrics\":" + lyricsStored + ",\"errors\":[");
+        for (int i = 0; i < errors.size(); i++) {
+            if (i > 0) out.print(",");
+            out.print("\"" + errors.get(i).replace("\\", "\\\\").replace("\"", "\\\"") + "\"");
+        }
+        out.print("]}");
+    }
+}

--- a/src/main/java/com/github/skeliit/LyricsExportServlet.java
+++ b/src/main/java/com/github/skeliit/LyricsExportServlet.java
@@ -1,0 +1,100 @@
+package com.github.skeliit;
+
+import com.github.skeliit.dao.LyricDao;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * Exports lyrics as TTML files in a zip archive, ready for submission
+ * to Apple Music via DistroKid, TuneCore, or Musixmatch.
+ *
+ * GET /admin/lyrics-export          — all songs, all languages
+ * GET /admin/lyrics-export?lang=cs  — filter by language
+ * GET /admin/lyrics-export?timed=1  — only songs that have timed (TTML) lyrics
+ */
+@WebServlet(name = "LyricsExportServlet", urlPatterns = {"/admin/lyrics-export"})
+public class LyricsExportServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        Object role = req.getSession().getAttribute("role");
+        if (role == null || !"ADMIN".equals(role.toString())) {
+            resp.setStatus(403);
+            resp.getWriter().write("Forbidden");
+            return;
+        }
+
+        String langFilter = req.getParameter("lang");
+        boolean timedOnly = "1".equals(req.getParameter("timed"));
+
+        List<LyricDao.LyricExportRow> rows;
+        try {
+            rows = new LyricDao().listForExport();
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+
+        resp.setContentType("application/zip");
+        resp.setHeader("Content-Disposition", "attachment; filename=\"skeli-lyrics-export.zip\"");
+
+        try (ZipOutputStream zip = new ZipOutputStream(resp.getOutputStream(), StandardCharsets.UTF_8)) {
+            for (LyricDao.LyricExportRow row : rows) {
+                if (langFilter != null && !langFilter.isBlank() && !langFilter.equals(row.lang())) continue;
+                if (timedOnly && (row.timedLyrics() == null || row.timedLyrics().isBlank())) continue;
+
+                String ttml = row.timedLyrics() != null && !row.timedLyrics().isBlank()
+                        ? row.timedLyrics()
+                        : buildSimpleTtml(row);
+
+                String filename = sanitize(row.songName()) + "_" + row.lang() + ".ttml";
+                zip.putNextEntry(new ZipEntry(filename));
+                zip.write(ttml.getBytes(StandardCharsets.UTF_8));
+                zip.closeEntry();
+            }
+        }
+    }
+
+    /** Wraps plain-text lyrics in minimal valid TTML for distributor submission. */
+    private static String buildSimpleTtml(LyricDao.LyricExportRow row) {
+        String year = row.year() != null ? String.valueOf(row.year()) : String.valueOf(LocalDate.now().getYear());
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        sb.append("<tt xmlns=\"http://www.w3.org/ns/ttml\"\n");
+        sb.append("    xmlns:ttm=\"http://www.w3.org/ns/ttml#metadata\"\n");
+        sb.append("    xml:lang=\"").append(escapeXml(row.lang())).append("\">\n");
+        sb.append("  <head>\n    <metadata>\n");
+        sb.append("      <ttm:title>").append(escapeXml(row.songName())).append("</ttm:title>\n");
+        sb.append("      <ttm:copyright>© ").append(year).append(" Skeli</ttm:copyright>\n");
+        sb.append("    </metadata>\n  </head>\n");
+        sb.append("  <body>\n    <div>\n");
+        if (row.words() != null) {
+            for (String line : row.words().split("\n")) {
+                String trimmed = line.trim();
+                if (!trimmed.isEmpty()) {
+                    sb.append("      <p>").append(escapeXml(trimmed)).append("</p>\n");
+                }
+            }
+        }
+        sb.append("    </div>\n  </body>\n</tt>\n");
+        return sb.toString();
+    }
+
+    private static String sanitize(String name) {
+        return name == null ? "unknown" : name.replaceAll("[^a-zA-Z0-9_\\-]", "_");
+    }
+
+    private static String escapeXml(String s) {
+        if (s == null) return "";
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;");
+    }
+}

--- a/src/main/java/com/github/skeliit/dao/LyricDao.java
+++ b/src/main/java/com/github/skeliit/dao/LyricDao.java
@@ -14,7 +14,7 @@ public class LyricDao {
         if (lang == null || lang.isEmpty()) lang = "cs";
         
         // First try to find lyric in requested language
-        String sql = "SELECT s.name AS song_name, s.year AS song_year, l.words, l.song_id, l.id, l.lang, " +
+        String sql = "SELECT s.name AS song_name, s.year AS song_year, s.apple_music_id, l.words, l.song_id, l.id, l.lang, " +
                 "(SELECT v.youtube_id FROM videos v WHERE v.song_id = l.song_id ORDER BY v.published_at DESC, v.id DESC LIMIT 1) AS yt " +
                 "FROM lyrics l JOIN songs s ON s.id = l.song_id WHERE l.id = ? AND l.lang = ?";
         
@@ -26,7 +26,7 @@ public class LyricDao {
                 if (!rs.next()) {
                     // Fallback to Czech version if translation not found
                     try (PreparedStatement ps2 = c.prepareStatement(
-                            "SELECT s.name AS song_name, s.year AS song_year, l.words, l.song_id, l.id, l.lang, " +
+                            "SELECT s.name AS song_name, s.year AS song_year, s.apple_music_id, l.words, l.song_id, l.id, l.lang, " +
                             "(SELECT v.youtube_id FROM videos v WHERE v.song_id = l.song_id ORDER BY v.published_at DESC, v.id DESC LIMIT 1) AS yt " +
                             "FROM lyrics l JOIN songs s ON s.id = l.song_id WHERE l.id = ? AND l.lang = 'cs'")) {
                         ps2.setInt(1, lyricId);
@@ -51,6 +51,7 @@ public class LyricDao {
         int y = rs.getInt("song_year"); v.year = rs.wasNull()? null : y;
         v.words = rs.getString("words");
         v.youtubeId = rs.getString("yt");
+        v.appleMusicId = rs.getString("apple_music_id");
         
         // YouTube fallback logic
         if (v.youtubeId == null || v.youtubeId.isBlank()) {
@@ -120,6 +121,58 @@ public class LyricDao {
                     out.add(cv);
                 }
                 return out;
+            }
+        }
+    }
+
+    public record LyricExportRow(int songId, String songName, Integer year, String lang, String words, String timedLyrics) {}
+
+    public List<LyricExportRow> listForExport() throws SQLException {
+        String sql = "SELECT s.id AS song_id, s.name AS song_name, s.year AS song_year, " +
+                "l.lang, l.words, l.timed_lyrics " +
+                "FROM lyrics l JOIN songs s ON s.id = l.song_id " +
+                "ORDER BY s.name ASC, l.lang ASC";
+        try (Connection c = Db.get(); PreparedStatement ps = c.prepareStatement(sql); ResultSet rs = ps.executeQuery()) {
+            List<LyricExportRow> out = new ArrayList<>();
+            while (rs.next()) {
+                int y = rs.getInt("song_year");
+                out.add(new LyricExportRow(
+                        rs.getInt("song_id"),
+                        rs.getString("song_name"),
+                        rs.wasNull() ? null : y,
+                        rs.getString("lang"),
+                        rs.getString("words"),
+                        rs.getString("timed_lyrics")
+                ));
+            }
+            return out;
+        }
+    }
+
+    public void upsertAppleMusicLyrics(int songId, String plainText, String timedTtml, String lang) throws SQLException {
+        try (Connection c = Db.get()) {
+            try (PreparedStatement sel = c.prepareStatement("SELECT id FROM lyrics WHERE song_id=? AND lang=?")) {
+                sel.setInt(1, songId);
+                sel.setString(2, lang);
+                try (ResultSet rs = sel.executeQuery()) {
+                    if (rs.next()) {
+                        int id = rs.getInt(1);
+                        try (PreparedStatement upd = c.prepareStatement("UPDATE lyrics SET words=?, timed_lyrics=? WHERE id=?")) {
+                            upd.setString(1, plainText);
+                            upd.setString(2, timedTtml);
+                            upd.setInt(3, id);
+                            upd.executeUpdate();
+                        }
+                    } else {
+                        try (PreparedStatement ins = c.prepareStatement("INSERT INTO lyrics (song_id, lang, words, timed_lyrics, score) VALUES (?,?,?,?,0)")) {
+                            ins.setInt(1, songId);
+                            ins.setString(2, lang);
+                            ins.setString(3, plainText);
+                            ins.setString(4, timedTtml);
+                            ins.executeUpdate();
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/main/java/com/github/skeliit/dao/SongDao.java
+++ b/src/main/java/com/github/skeliit/dao/SongDao.java
@@ -9,18 +9,44 @@ import java.util.List;
 
 public class SongDao {
     public List<Song> listWithFirstLyric() throws SQLException {
-        String sql = "SELECT s.id, s.name, s.year, (SELECT MIN(l.id) FROM lyrics l WHERE l.song_id=s.id) AS firstLyricId FROM songs s ORDER BY s.name ASC";
+        String sql = "SELECT s.id, s.name, s.year, s.apple_music_id, (SELECT MIN(l.id) FROM lyrics l WHERE l.song_id=s.id) AS firstLyricId FROM songs s ORDER BY s.name ASC";
         try (Connection c = Db.get(); PreparedStatement ps = c.prepareStatement(sql); ResultSet rs = ps.executeQuery()) {
             List<Song> out = new ArrayList<>();
             while (rs.next()) {
-                Song s = new Song();
-                s.id = rs.getInt("id");
-                s.name = rs.getString("name");
-                int y = rs.getInt("year"); s.year = rs.wasNull()? null : y;
-                int fl = rs.getInt("firstLyricId"); s.firstLyricId = rs.wasNull()? null : fl;
-                out.add(s);
+                out.add(mapSong(rs, true));
             }
             return out;
         }
+    }
+
+    public List<Song> listAll() throws SQLException {
+        String sql = "SELECT id, name, year, uuid, apple_music_id FROM songs ORDER BY name ASC";
+        try (Connection c = Db.get(); PreparedStatement ps = c.prepareStatement(sql); ResultSet rs = ps.executeQuery()) {
+            List<Song> out = new ArrayList<>();
+            while (rs.next()) {
+                out.add(mapSong(rs, false));
+            }
+            return out;
+        }
+    }
+
+    public void updateAppleMusicId(int songId, String appleMusicId) throws SQLException {
+        try (Connection c = Db.get(); PreparedStatement ps = c.prepareStatement("UPDATE songs SET apple_music_id=? WHERE id=?")) {
+            ps.setString(1, appleMusicId);
+            ps.setInt(2, songId);
+            ps.executeUpdate();
+        }
+    }
+
+    private Song mapSong(ResultSet rs, boolean withFirstLyric) throws SQLException {
+        Song s = new Song();
+        s.id = rs.getInt("id");
+        s.name = rs.getString("name");
+        int y = rs.getInt("year"); s.year = rs.wasNull() ? null : y;
+        s.appleMusicId = rs.getString("apple_music_id");
+        if (withFirstLyric) {
+            int fl = rs.getInt("firstLyricId"); s.firstLyricId = rs.wasNull() ? null : fl;
+        }
+        return s;
     }
 }

--- a/src/main/java/com/github/skeliit/model/LyricView.java
+++ b/src/main/java/com/github/skeliit/model/LyricView.java
@@ -10,6 +10,7 @@ public class LyricView {
     public long views;
     public int votesUp;
     public int votesDown;
+    public String appleMusicId;
 
     // Getters for EL expressions
     public int getId() { return id; }
@@ -21,4 +22,5 @@ public class LyricView {
     public long getViews() { return views; }
     public int getVotesUp() { return votesUp; }
     public int getVotesDown() { return votesDown; }
+    public String getAppleMusicId() { return appleMusicId; }
 }

--- a/src/main/java/com/github/skeliit/model/Song.java
+++ b/src/main/java/com/github/skeliit/model/Song.java
@@ -6,6 +6,7 @@ public class Song {
     public String name;
     public Integer year;
     public Integer firstLyricId;
+    public String appleMusicId;
 
     // Getters for EL expressions
     public int getId() { return id; }
@@ -13,4 +14,5 @@ public class Song {
     public String getName() { return name; }
     public Integer getYear() { return year; }
     public Integer getFirstLyricId() { return firstLyricId; }
+    public String getAppleMusicId() { return appleMusicId; }
 }

--- a/src/main/java/com/github/skeliit/service/AppleMusicClient.java
+++ b/src/main/java/com/github/skeliit/service/AppleMusicClient.java
@@ -1,0 +1,194 @@
+package com.github.skeliit.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+public class AppleMusicClient {
+
+    public record SongMatch(String id, String name, String releaseDate) {}
+    public record AppleMusicLyrics(String ttml, String plainText) {}
+
+    private final String teamId;
+    private final String keyId;
+    private final String privateKeyPem;
+    private final String userToken;
+    private final String storefront;
+    private final String artistName;
+    private final HttpClient http;
+    private final ObjectMapper mapper;
+
+    private volatile String cachedToken;
+    private volatile long tokenExpiry;
+
+    public AppleMusicClient(String teamId, String keyId, String privateKeyPem,
+                            String userToken, String storefront, String artistName) {
+        this.teamId = teamId;
+        this.keyId = keyId;
+        this.privateKeyPem = privateKeyPem;
+        this.userToken = userToken;
+        this.storefront = storefront;
+        this.artistName = artistName;
+        this.http = HttpClient.newHttpClient();
+        this.mapper = new ObjectMapper();
+    }
+
+    private String devToken() throws Exception {
+        long now = System.currentTimeMillis() / 1000;
+        if (cachedToken != null && now < tokenExpiry - 60) return cachedToken;
+
+        String pem = privateKeyPem
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s+", "");
+        byte[] keyBytes = Base64.getDecoder().decode(pem);
+        ECPrivateKey privateKey = (ECPrivateKey) KeyFactory.getInstance("EC")
+                .generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
+
+        long exp = now + 15_777_000L;
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(keyId).build();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(teamId)
+                .issueTime(new Date(now * 1000))
+                .expirationTime(new Date(exp * 1000))
+                .build();
+        SignedJWT jwt = new SignedJWT(header, claims);
+        jwt.sign(new ECDSASigner(privateKey));
+
+        cachedToken = jwt.serialize();
+        tokenExpiry = exp;
+        return cachedToken;
+    }
+
+    public SongMatch searchSong(String songName, Integer year) throws Exception {
+        String query = URLEncoder.encode(artistName + " " + songName, StandardCharsets.UTF_8);
+        String url = "https://api.music.apple.com/v1/catalog/" + storefront +
+                "/search?types=songs&term=" + query + "&limit=5";
+
+        String body = get(url, false);
+        JsonNode data = mapper.readTree(body).path("results").path("songs").path("data");
+        if (!data.isArray() || data.isEmpty()) return null;
+
+        // Pick best match: prefer exact name match + year match
+        String normalSong = normalize(songName);
+        SongMatch best = null;
+        int bestScore = -1;
+        for (JsonNode item : data) {
+            String id = item.path("id").asText(null);
+            JsonNode attr = item.path("attributes");
+            String name = attr.path("name").asText("");
+            String artist = attr.path("artistName").asText("");
+            String releaseDate = attr.path("releaseDate").asText("");
+
+            int score = 0;
+            if (normalize(name).contains(normalSong)) score += 2;
+            if (normalize(artist).contains(normalize(artistName))) score += 1;
+            if (year != null && releaseDate.startsWith(String.valueOf(year))) score += 2;
+
+            if (score > bestScore) {
+                bestScore = score;
+                best = new SongMatch(id, name, releaseDate);
+            }
+        }
+        return (bestScore >= 1) ? best : null;
+    }
+
+    public List<SongMatch> listArtistSongs(String artistId) throws Exception {
+        List<SongMatch> all = new ArrayList<>();
+        String url = "https://api.music.apple.com/v1/catalog/" + storefront +
+                "/artists/" + artistId + "/relationships/songs?limit=100";
+        while (url != null) {
+            String body = get(url, false);
+            JsonNode root = mapper.readTree(body);
+            for (JsonNode item : root.path("data")) {
+                String id = item.path("id").asText(null);
+                if (id == null) continue;
+                JsonNode attr = item.path("attributes");
+                all.add(new SongMatch(id, attr.path("name").asText(""), attr.path("releaseDate").asText("")));
+            }
+            JsonNode next = root.path("next");
+            url = (next.isMissingNode() || next.isNull() || next.asText("").isBlank())
+                    ? null
+                    : "https://api.music.apple.com" + next.asText();
+        }
+        return all;
+    }
+
+    public AppleMusicLyrics fetchLyrics(String appleMusicId) throws Exception {
+        if (userToken == null || userToken.isBlank()) return null;
+        String url = "https://api.music.apple.com/v1/catalog/" + storefront +
+                "/songs/" + appleMusicId + "/lyrics";
+        String body = get(url, true);
+        JsonNode data = mapper.readTree(body).path("data");
+        if (!data.isArray() || data.isEmpty()) return null;
+        String ttml = data.get(0).path("attributes").path("ttml").asText(null);
+        if (ttml == null || ttml.isBlank()) return null;
+        return new AppleMusicLyrics(ttml, ttmlToPlainText(ttml));
+    }
+
+    private String get(String url, boolean withUserToken) throws Exception {
+        HttpRequest.Builder req = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Authorization", "Bearer " + devToken())
+                .header("Accept", "application/json")
+                .GET();
+        if (withUserToken) req.header("Music-User-Token", userToken);
+        HttpResponse<String> resp = http.send(req.build(), HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() != 200) {
+            throw new RuntimeException("Apple Music API error " + resp.statusCode() + ": " + resp.body());
+        }
+        return resp.body();
+    }
+
+    private static String ttmlToPlainText(String ttml) {
+        try {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(true);
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            Document doc = dbf.newDocumentBuilder().parse(new InputSource(new StringReader(ttml)));
+            NodeList paragraphs = doc.getElementsByTagNameNS("*", "p");
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < paragraphs.getLength(); i++) {
+                String text = paragraphs.item(i).getTextContent().trim();
+                if (!text.isEmpty()) sb.append(text).append("\n");
+            }
+            return sb.toString().trim();
+        } catch (Exception e) {
+            // Strip XML tags as fallback
+            return ttml.replaceAll("<[^>]+>", "").replaceAll("\\s+", " ").trim();
+        }
+    }
+
+    public static String normalize(String s) {
+        if (s == null) return "";
+        return java.text.Normalizer.normalize(s, java.text.Normalizer.Form.NFD)
+                .replaceAll("\\p{InCombiningDiacriticalMarks}+", "")
+                .toLowerCase()
+                .replaceAll("[^a-z0-9 ]+", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+}

--- a/src/main/resources/db/migration/V33__apple_music.sql
+++ b/src/main/resources/db/migration/V33__apple_music.sql
@@ -1,0 +1,10 @@
+START TRANSACTION;
+
+ALTER TABLE `songs`
+  ADD COLUMN `apple_music_id` VARCHAR(20) DEFAULT NULL,
+  ADD UNIQUE KEY `uq_songs_apple_music_id` (`apple_music_id`);
+
+ALTER TABLE `lyrics`
+  ADD COLUMN `timed_lyrics` LONGTEXT DEFAULT NULL;
+
+COMMIT;

--- a/src/main/webapp/WEB-INF/views/lyric.jsp
+++ b/src/main/webapp/WEB-INF/views/lyric.jsp
@@ -271,6 +271,11 @@
               <i class="fab fa-youtube" style="color:#FF0000;"></i> YouTube
             </a>
           </c:if>
+          <c:if test="${not empty lyric.appleMusicId}">
+            <a class="action-btn" href="https://music.apple.com/song/${lyric.appleMusicId}" target="_blank" rel="noopener" title="Otevřít na Apple Music">
+              <i class="fab fa-apple" style="color:#fc3c44;"></i> Apple Music
+            </a>
+          </c:if>
         </div>
         
         <div class="views-count">Návštěvy: ${lyric.views}</div>


### PR DESCRIPTION
## Summary

- **DB migration V33**: adds `apple_music_id` column to `songs` and `timed_lyrics` column to `lyrics`
- **`AppleMusicClient`** service: generates ES256 JWT developer tokens (MusicKit), searches the Apple Music catalog by artist + song name, enumerates all songs in the artist's catalog via the artist relationship endpoint, and fetches time-synced TTML lyrics
- **`AppleMusicSyncServlet`** at `/admin/apple-sync`: iterates all DB songs, matches each to an Apple Music catalog entry (using full artist catalog when `APPLE_MUSIC_ARTIST_ID` is set — more accurate than per-song text search), stores the Apple Music song ID, then fetches and stores TTML lyrics
- **`LyricsExportServlet`** at `/admin/lyrics-export`: downloads a zip of `.ttml` files per song/language, ready for submission to DistroKid, TuneCore, or Musixmatch (supports `?lang=cs`, `?lang=en`, `?timed=1` filters)
- **`Song` / `LyricView` models**: extended with `appleMusicId` field
- **`lyric.jsp`**: shows an "Apple Music" action button when `apple_music_id` is populated
- **`.env.example`**: documents all six `APPLE_MUSIC_*` env vars including `APPLE_MUSIC_ARTIST_ID`
- **`pom.xml`**: adds `com.nimbusds:nimbus-jose-jwt:9.37.3` for ES256 JWT signing

## Setup

1. Enroll in Apple Developer Program → create a MusicKit key → note Team ID, Key ID, download `.p8`
2. (Optional) Obtain a Music User Token for lyrics fetch
3. Set `APPLE_MUSIC_*` vars in `.env` (see `.env.example`)
4. Run `mvn flyway:migrate` to apply V33
5. Hit `GET /admin/apple-sync` while logged in as ADMIN

## Test plan

- [ ] `mvn flyway:migrate` applies V33 without error
- [ ] `mvn compile` succeeds
- [ ] `GET /admin/apple-sync` returns `{"synced":N,"lyrics":M,"errors":[]}` for a configured instance
- [ ] `SELECT apple_music_id FROM songs LIMIT 5` returns non-null values after sync
- [ ] Lyric page shows "Apple Music" button when `apple_music_id` is set
- [ ] `GET /admin/lyrics-export` downloads a valid zip containing `.ttml` files
- [ ] `GET /admin/lyrics-export?timed=1` returns only songs with stored TTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Přidána integrace s Apple Music pro synchronizaci skladeb a jejich textů s katalogem
  * Nový export funkcionalita pro stahování textů jako TTML souborů zabalených v ZIP archivu
  * Zobrazení Apple Music odkazu pro skladby s propojeným identifikátorem

* **Chores**
  * Aktualizace závislostí pro podporu JWT autentizace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->